### PR TITLE
Fix #1: Add report issue button to map-dmg-calc.html

### DIFF
--- a/map-dmg-calc.html
+++ b/map-dmg-calc.html
@@ -185,6 +185,7 @@
 
 <div class="sidebar">
   <a href="index.html" class="back-link">&larr; Maps Explorer</a>
+  <a href="https://github.com/Maaaaaarrk/pd2_maps_explorer/issues" target="_blank" class="back-link" style="float:right">Report Issue</a>
 
   <h2>Breaking Pierce</h2>
   <p class="desc">Immunity-breaking effects (Conviction, Lower Resist)</p>


### PR DESCRIPTION
## Summary
- Adds a "Report Issue" link to the sidebar of `map-dmg-calc.html`, matching the pattern used in `index.html`
- Links to the GitHub issues page for the repo

Closes #1

## Test plan
- [ ] Open `map-dmg-calc.html` and verify the "Report Issue" link appears in the sidebar
- [ ] Click the link and verify it opens the GitHub issues page in a new tab

Generated with Claude Code