### PR TITLE
Fix crushing blow damage decay in map damage calculator

### DIFF
--- a/map-dmg-calc.html
+++ b/map-dmg-calc.html
@@ -300,14 +300,14 @@ function calcDmgHit(dmg, res, pierceNon, pierceBreak) {
 }
 
 // Crushing Blow damage per hit for a source against a monster (Season 13 mechanics).
-// CB deals flat damage based on max HP (does NOT decay with current HP).
+// CB deals damage based on CURRENT HP (decays as monster loses life).
 // Divisor scales from 7 (players 1) to 16.8 (players 8).
 // Ranged attacks apply a 1.5x multiplier to the divisor.
-function cbDmgPerHit(src, monMaxHp) {
+function cbDmgPerHit(src, currentHp) {
   if (!src.cbChance || src.cbChance <= 0) return 0;
   const cbDivisor = 7 + (state.playerCount - 1) * 1.4;
   const rangedMult = src.ranged ? 1.5 : 1;
-  const baseCbDmg = monMaxHp / (cbDivisor * rangedMult);
+  const baseCbDmg = currentHp / (cbDivisor * rangedMult);
   return baseCbDmg * (Math.min(src.cbChance, 100) / 100);
 }
 
@@ -325,11 +325,13 @@ function sourceDps(src, monster) {
   return dmgPerHit * hitsPerSec;
 }
 
-// Crushing blow DPS for a source (physical damage, uses phys res)
-function sourceCbDps(src, monster) {
+// Crushing blow DPS for a source (physical damage, uses phys res).
+// When currentHp is provided, CB damage is based on that value (for simulation).
+// Otherwise uses monsterMaxHp (for initial DPS display).
+function sourceCbDps(src, monster, currentHp) {
   if (!src.cbChance || src.fpa <= 0) return 0;
-  const maxHp = monsterMaxHp(monster);
-  const rawCb = cbDmgPerHit(src, maxHp);
+  const hp = currentHp !== undefined ? currentHp : monsterMaxHp(monster);
+  const rawCb = cbDmgPerHit(src, hp);
   // CB deals physical damage, apply physical resistance
   const physRes = monster[ELEM_MAP["phys"].resKey];
   const cbAfterRes = calcDmgHit(rawCb, physRes, 0, state.breaking["phys"]);
@@ -371,12 +373,58 @@ function monsterMaxHp(mon) {
 }
 
 function hasSources() {
-  return state.sources.some(s => s.dmg > 0);
+  return state.sources.some(s => s.dmg > 0 || s.cbChance > 0);
 }
 
 function hasElemSources(elemKey) {
   if (elemKey === "phys" && state.sources.some(s => s.cbChance > 0)) return true;
   return state.sources.some(s => s.type === elemKey && s.dmg > 0);
+}
+
+// Simulate time-to-kill accounting for CB damage decay.
+// CB damage is based on current HP, so it decreases as the monster takes damage.
+// Returns { ttk, hpAfter1s } where ttk is in seconds and hpAfter1s is HP remaining after 1s.
+function simulateTTK(monster) {
+  const maxHp = monsterMaxHp(monster);
+  let hp = maxHp;
+  // Flat DPS from non-CB sources (constant over time)
+  const flatDps = state.sources.reduce((sum, src) => sum + sourceDps(src, monster), 0);
+  // Check if there are any CB sources
+  const hasCb = state.sources.some(s => s.cbChance > 0 && s.fpa > 0);
+  if (!hasCb) {
+    // No CB: simple calculation
+    const dps = flatDps;
+    if (dps <= 0) return { ttk: Infinity, hpAfter1s: maxHp, initialDps: 0 };
+    return { ttk: maxHp / dps, hpAfter1s: Math.max(maxHp - dps, 0), initialDps: dps };
+  }
+  // Simulate frame-by-frame for CB decay
+  const flatDmgPerFrame = flatDps / FRAMES_PER_SEC;
+  const physRes = monster[ELEM_MAP["phys"].resKey];
+  const physResAfter = calcRes(physRes, 0, state.breaking["phys"]);
+  const cbResMult = physResAfter > 99 ? 0 : physResAfter < 0 ? (1 + Math.abs(physResAfter) / 100) : (1 - physResAfter / 100);
+  let frame = 0;
+  const maxFrames = FRAMES_PER_SEC * 600; // cap at 600 seconds
+  let hpAfter1s = null;
+  while (hp > 0.5 && frame < maxFrames) {
+    // Apply flat damage this frame
+    hp -= flatDmgPerFrame;
+    // Apply CB hits this frame
+    for (const src of state.sources) {
+      if (!src.cbChance || src.cbChance <= 0 || src.fpa <= 0) continue;
+      // Check if this source hits on this frame
+      if (frame % src.fpa === 0) {
+        const rawCb = cbDmgPerHit(src, Math.max(hp, 0));
+        hp -= rawCb * cbResMult;
+      }
+    }
+    frame++;
+    if (frame === FRAMES_PER_SEC) hpAfter1s = hp;
+  }
+  if (hpAfter1s === null) hpAfter1s = hp;
+  const ttk = hp <= 0 ? frame / FRAMES_PER_SEC : Infinity;
+  // Initial DPS includes CB at full HP for display
+  const initialCbDps = state.sources.reduce((sum, src) => sum + sourceCbDps(src, monster, maxHp), 0);
+  return { ttk, hpAfter1s: Math.max(hpAfter1s, 0), initialDps: flatDps + initialCbDps };
 }
 
 // ---- UI: Breaking Pierce ----
@@ -552,13 +600,13 @@ function render() {
         </td>`;
       });
 
-      const dps = Math.round(totalDps(mon));
       const maxHp = Math.round(monsterMaxHp(mon));
-      const ttk = dps > 0 ? (maxHp / dps) : Infinity;
+      const sim = simulateTTK(mon);
+      const dps = Math.round(sim.initialDps);
+      const ttk = sim.ttk;
       const ttkDisplay = ttk === Infinity ? "-" : ttk < 1 ? "<1s" : ttk.toFixed(1) + "s";
-      const pct = maxHp > 0 ? (dps / maxHp) * 100 : 0;
-      const dead = pct >= 100;
-      const remaining = Math.max(100 - pct, 0);
+      const remaining = maxHp > 0 ? Math.max(sim.hpAfter1s / monsterMaxHp(mon) * 100, 0) : 100;
+      const dead = remaining <= 0;
 
       html += `<td class="sum-cell"><span class="sum-dmg">${dps.toLocaleString()}/s</span></td>`;
       html += `<td class="sum-cell"><div class="hp-bar-wrap">


### PR DESCRIPTION
## Summary
Closes #7

- **Crushing blow now uses current HP instead of max HP**, so CB damage correctly decays as the monster loses life. Previously, CB was treated as flat damage based on max HP, which made monsters appear to die unrealistically fast with CB-only builds.
- **Added frame-by-frame TTK simulation** when CB sources are present. The simple `maxHp / dps` formula doesn't work for CB since the damage decreases over time. The simulation steps through each frame, applying flat damage and CB hits at the correct intervals.
- **Fixed `hasSources()` to recognize CB-only damage sources** (where dmg=0 but cbChance>0), so the UI correctly shows active state for CB-only configurations.
- HP bar after 1 second now reflects the simulated HP with CB decay rather than the linear approximation.

## Test plan
- [ ] Open the URL from the issue: `map-dmg-calc.html#src=phys.0.0.10.100.1&maps=171` and verify monsters no longer show as dying instantly with CB-only damage
- [ ] Test with mixed damage (flat + CB) to verify TTK is reasonable
- [ ] Test with no CB sources to verify the simple TTK path still works correctly
- [ ] Test with ranged CB to verify the ranged multiplier still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)