### PR TITLE
Fix #9: Change base crushing blow from 1/7 to 1/8

### DIFF
--- a/map-dmg-calc.html
+++ b/map-dmg-calc.html
@@ -301,11 +301,11 @@ function calcDmgHit(dmg, res, pierceNon, pierceBreak) {
 
 // Crushing Blow damage per hit for a source against a monster (Season 13 mechanics).
 // CB deals damage based on CURRENT HP (decays as monster loses life).
-// Divisor scales from 7 (players 1) to 16.8 (players 8).
+// Divisor scales from 8 (players 1) to 17.8 (players 8).
 // Ranged attacks apply a 1.5x multiplier to the divisor.
 function cbDmgPerHit(src, currentHp) {
   if (!src.cbChance || src.cbChance <= 0) return 0;
-  const cbDivisor = 7 + (state.playerCount - 1) * 1.4;
+  const cbDivisor = 8 + (state.playerCount - 1) * 1.4;
   const rangedMult = src.ranged ? 1.5 : 1;
   const baseCbDmg = currentHp / (cbDivisor * rangedMult);
   return baseCbDmg * (Math.min(src.cbChance, 100) / 100);


### PR DESCRIPTION
## Summary
- Changes the base crushing blow divisor from 7 (1/7) to 8 (1/8) in the damage calculator
- Updates the scaling comment to reflect the new range: 8 (players 1) to 17.8 (players 8)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)