### PR TITLE
Fix #17: run restoreFromHash after const declarations

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,7 +439,6 @@ function restoreFromHash() {
   }
 }
 
-restoreFromHash();
 window.addEventListener("hashchange", restoreFromHash);
 
 function showLevel(levelId, displayName) {
@@ -621,6 +620,11 @@ function buildMonsterTable(monsters, areaLvl) {
   html += "</tbody></table>";
   return html;
 }
+
+// Run after all const declarations above are initialized, so deep-linking
+// (e.g. #endgame/0/169) can call showLevel -> buildMonsterTable -> resStyle
+// without hitting a temporal dead zone on RES_BG.
+restoreFromHash();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Fixes #17: deep-linking via URL hash (e.g. `#endgame/0/169`) only showed the dropdown and the page seemed stuck.
- Root cause: `restoreFromHash()` was invoked mid-script, before the `const RES_BG = {...}` block (and the function expressions that depend on it) was initialized. On initial load `restoreFromHash` -> `showLevel` -> `buildMonsterTable` -> `resStyle` threw `ReferenceError: Cannot access 'RES_BG' before initialization` (temporal dead zone). `showLevel` aborted before marking `#levelPanel` visible, so only the dropdown was visible.
- Fix: move the initial `restoreFromHash()` call to the very end of the `<script>` block so all top-level `const` bindings are initialized first. The `hashchange` listener registration stays where it was (function declaration `restoreFromHash` is hoisted, so this is fine).

## Test plan

- [x] Reproduce in JSDOM with `#endgame/0/169`: before fix, `#levelPanel` is hidden and monster table is empty. After fix, panel is visible and the full monster table for Shadows of Westmarch renders.
- [x] Smoke-test other deep links (`#campaign/2`, no-hash) -- all behave correctly.
- [ ] Manual: open `https://maaaaaarrk.github.io/pd2_maps_explorer/index.html#endgame/0/169` after deploy and confirm Shadows of Westmarch detail loads on first visit.

Closes #17